### PR TITLE
Add package.xml for building

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>python-transitions</name>
+  <version>0.4.3</version>
+  <description>A lightweight, object-oriented finite state machine implementation in Python</description>
+  <maintainer email="tyarkoni@gmail.com">Tal Yarkoni</maintainer>
+  <license>MIT License</license>
+
+  <buildtool_depend>python</buildtool_depend>
+  <exec_depend>six</exec_depend>
+  
+  <export><build_type>python</build_type></export>
+</package>


### PR DESCRIPTION
Add a package.xml file to the repo so that this can be built as part of the bundle build.

The repo has been tested with catkin build and compiles successfully.

I need to verify the version that is being depended on, for now I've left it set as 0.4.3

@mikepurvis 